### PR TITLE
fix: provide default shell and working-directory

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -18,8 +18,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    env:
-      working-directory: api
+    defaults:
+      run:
+        shell: bash
+        working-directory: api
 
     strategy:
       matrix:


### PR DESCRIPTION
Provide default shell and working-directory to all run steps in the job